### PR TITLE
Update UiClassDiagram to reflect renamed UI classes

### DIFF
--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -11,8 +11,8 @@ Class UiManager
 Class MainWindow
 Class HelpWindow
 Class ResultDisplay
-Class PersonListPanel
-Class PersonCard
+Class TripListPanel
+Class TripCard
 Class StatusBarFooter
 Class CommandBox
 }
@@ -32,26 +32,26 @@ UiManager .left.|> Ui
 UiManager -down-> "1" MainWindow
 MainWindow *-down->  "1" CommandBox
 MainWindow *-down-> "1" ResultDisplay
-MainWindow *-down-> "1" PersonListPanel
+MainWindow *-down-> "1" TripListPanel
 MainWindow *-down-> "1" StatusBarFooter
 MainWindow --> "0..1" HelpWindow
 
-PersonListPanel -down-> "*" PersonCard
+TripListPanel -down-> "*" TripCard
 
 MainWindow -left-|> UiPart
 
 ResultDisplay --|> UiPart
 CommandBox --|> UiPart
-PersonListPanel --|> UiPart
-PersonCard --|> UiPart
+TripListPanel --|> UiPart
+TripCard --|> UiPart
 StatusBarFooter --|> UiPart
 HelpWindow --|> UiPart
 
-PersonCard ..> Model
+TripCard ..> Model
 UiManager -right-> Logic
 MainWindow -left-> Logic
 
-PersonListPanel -[hidden]left- HelpWindow
+TripListPanel -[hidden]left- HelpWindow
 HelpWindow -[hidden]left- CommandBox
 CommandBox -[hidden]left- ResultDisplay
 ResultDisplay -[hidden]left- StatusBarFooter


### PR DESCRIPTION
This PR aims to resolve #86 on resolving the ui class names to be updated to reflect the Triplog domain instead of referencing the outdated class names from the original AB3 codebase in `UiClassDiagram.puml`

## Changes
1. Replace `PersonListPanel` with `TripListPanel` in class declaration, relationships, and layout arrows
2. Replace `PersonCard` with `TripCard` in class declaration, relationships, and hidden layout arrows

---

An image showing the reflected changes can be found below:
<img width="758" height="372" alt="Screenshot 2026-03-22 at 11 56 03 AM" src="https://github.com/user-attachments/assets/1873bd1b-fbb0-438b-ae75-64195532fff2" />

---