### PR TITLE
Fix command box text visibility and update UI tests

### DIFF
--- a/src/main/java/seedu/triplog/ui/CommandBox.java
+++ b/src/main/java/seedu/triplog/ui/CommandBox.java
@@ -63,9 +63,10 @@ public class CommandBox extends UiPart<Region> {
 
     /**
      * Resets the command box to the default state.
+     * Changed to black/dark text to be visible against the white background.
      */
     private void resetStyle() {
-        commandTextField.setStyle("-fx-text-fill: white;");
+        commandTextField.setStyle("-fx-text-fill: #1A1A1A;");
     }
 
     /**

--- a/src/test/java/seedu/triplog/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/triplog/ui/CommandBoxTest.java
@@ -74,7 +74,9 @@ public class CommandBoxTest {
         Platform.runLater(() -> commandTextField.setText("fai"));
         WaitForAsyncUtils.waitForFxEvents();
 
-        assertTrue(commandTextField.getStyle().contains("white"));
+        // Updated to check for the dark body text color instead of white
+        assertTrue(commandTextField.getStyle().contains("#1A1A1A"),
+                "Style should contain reset color #1A1A1A: " + commandTextField.getStyle());
         assertFalse(commandTextField.getStyle().contains("#ff4d4d"));
     }
 


### PR DESCRIPTION
This PR resolves #107 by fixing a UI bug where user input in the command box was invisible due to a color clash (white text on a white background). It also updates the corresponding UI tests to reflect the new color scheme.

## Key Implementation Details
- **UI Logic**: Updated `CommandBox#resetStyle()` in `CommandBox.java` to use the dark body text color (`#1A1A1A`) instead of `white`.
- **Styling**: Ensured that programmatic style overrides in Java align with the `-tl-text-body` design token defined in `DarkTheme.css`.
- **Test Suite**: Updated `CommandBoxTest.java` to assert that the text-fill color is `#1A1A1A` during the reset phase, replacing the outdated check for the string "white".