### PR TITLE
Branch assertions enable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ checkstyle {
 }
 
 test {
+    enableAssertions = true
     useJUnitPlatform()
     finalizedBy jacocoTestReport
     jvmArgs '--add-opens=javafx.graphics/com.sun.javafx.application=ALL-UNNAMED',


### PR DESCRIPTION
This PR aims to resolve #111 on enabling assertions by setting `enableAssertions = true` inside the `build.gradle` file.
- Note that assertions are enabled for both `./gradlew run` and `./gradlew test`.