### PR TITLE
Fix file/help button alignment

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -30,9 +30,9 @@
           <Insets top="10" right="20" bottom="20" left="20"/>
         </padding>
 
-        <HBox alignment="CENTER_LEFT" VBox.vgrow="NEVER" style="-fx-padding: 10 0 0 10;">
+        <HBox alignment="CENTER_LEFT" VBox.vgrow="NEVER" style="-fx-padding: 10 0 0 0;">
 
-          <MenuBar styleClass="menu-bubble-left">
+          <MenuBar styleClass="menu-bubble-left" >
             <menus>
               <Menu mnemonicParsing="false" text="File">
                 <items>

--- a/src/main/resources/view/MainWindowTitle.css
+++ b/src/main/resources/view/MainWindowTitle.css
@@ -10,20 +10,22 @@
 /* Left bubble (File) */
 .menu-bubble-left {
     -fx-background-color: rgba(255,165,0,0.85); /* Orange */
-    -fx-background-radius: 20 0 0 20;
+    -fx-background-radius: 15 0 0 15;
     -fx-padding: 0 5 0 5;
 }
 
 /* Right bubble (Help) */
 .menu-bubble-right {
     -fx-background-color: rgba(100,180,255,0.85); /* Blue */
-    -fx-background-radius: 0 20 20 0;
+    -fx-background-radius: 0 15 15 0;
     -fx-padding: 0 5 0 5;
 }
 
 /* Make sure the menus inside don't have their own grey backgrounds */
 .menu-bubble-left .menu, .menu-bubble-right .menu {
     -fx-background-color: transparent;
+    -fx-border-width: 0;
+    -fx-border-color: transparent;
 }
 
 .menu-bubble-left .menu .label, .menu-bubble-right .menu .label {


### PR DESCRIPTION
The file/help buttons seemed to be a little too far the right.

**Fixes:**

Adjusted the file/help buttons to be more well-aligned with the TripLog main title.