### PR TITLE
Resolve Help Command arguments to be case-insensitive 

### DIFF
--- a/src/main/java/seedu/triplog/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/triplog/logic/commands/HelpCommand.java
@@ -39,7 +39,7 @@ public class HelpCommand extends Command {
     }
 
     private static String getUsageForCommand(String commandWord) throws CommandException {
-        switch (commandWord) {
+        switch (commandWord.toLowerCase()) {
         case COMMAND_WORD:
             return MESSAGE_USAGE;
         case AddCommand.COMMAND_WORD:


### PR DESCRIPTION
This PR aims to resolve #186 on making sure that the commands are case insensitive for the help command.

## Summary of Changes
1. `HelpCommand.java` - add `.toLowerCase` method to user input to ensure case insensitivity