### PR TITLE
Fix error message indicator

### DIFF
--- a/src/main/java/seedu/triplog/ui/ResultDisplay.java
+++ b/src/main/java/seedu/triplog/ui/ResultDisplay.java
@@ -100,7 +100,8 @@ public class ResultDisplay extends UiPart<Region> {
     private boolean isError(String message) {
         String lower = message.toLowerCase();
         return Stream.of("invalid", "unknown", "error", "cannot", "failed", "exception",
-                        "must", "no such", "not allowed", "insufficient", "duplicate", "less than or equal")
+                        "must", "no such", "not allowed", "insufficient", "duplicate", "should not",
+                        "should be", "out of range", "less than or equal", "accepts exactly one")
                 .anyMatch(lower::contains);
     }
 }


### PR DESCRIPTION
Error message indicator now display [!!]  instead of [OK] when end index is more than start index for delete index-index, as well as for other error messages displaying [OK]