### PR TITLE
Fix issue of displaying null if start date and end date not filled

### DIFF
--- a/src/main/java/seedu/triplog/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/triplog/logic/commands/DeleteCommand.java
@@ -181,12 +181,21 @@ public class DeleteCommand extends Command {
 
         for (int i = 0; i < tripsToDelete.size(); i++) {
             Trip trip = tripsToDelete.get(i);
+
+            String start = trip.getStartDate() == null
+                    ? "No date"
+                    : trip.getStartDate().toString();
+
+            String end = trip.getEndDate() == null
+                    ? "No date"
+                    : trip.getEndDate().toString();
+
             sb.append(i + 1).append(". ")
                     .append(trip.getName())
                     .append(" (")
-                    .append(trip.getStartDate())
+                    .append(start)
                     .append(" to ")
-                    .append(trip.getEndDate())
+                    .append(end)
                     .append(")\n");
         }
 


### PR DESCRIPTION
### Description

The delete preview displays `"null"` for trips that do not have start and/or end dates, which is not user-friendly and may confuse end users.

`null` values are now handled when formatting the message and displays No date if not specified
