### PR TITLE
Update DuplicateTripException message to use "trips"

### DIFF
--- a/src/main/java/seedu/triplog/model/trip/exceptions/DuplicateTripException.java
+++ b/src/main/java/seedu/triplog/model/trip/exceptions/DuplicateTripException.java
@@ -1,11 +1,11 @@
 package seedu.triplog.model.trip.exceptions;
 
 /**
- * Signals that the operation will result in duplicate Persons (Persons are considered duplicates if they have the same
+ * Signals that the operation will result in duplicate Trips (Trips are considered duplicates if they have the same
  * identity).
  */
 public class DuplicateTripException extends RuntimeException {
     public DuplicateTripException() {
-        super("Operation would result in duplicate persons");
+        super("Operation would result in duplicate trips");
     }
 }


### PR DESCRIPTION
This PR resolves #207 by removing "AddressBook" residue from the `DuplicateTripException` message and its associated Javadoc.

### Key Implementation Details
* **Exception Layer**: Updated the string literal in the `DuplicateTripException` constructor from "duplicate persons" to "duplicate trips".
* **Javadoc**: Refactored the class-level documentation to replace "Persons" with "Trips" for terminological consistency.

### Documentation
* No User Guide or Developer Guide updates required as this fix only affects an internal error message and source code comments.