### PR TITLE
Update Project Portfolio for ths1959

### DIFF
--- a/docs/team/ths1959.md
+++ b/docs/team/ths1959.md
@@ -2,21 +2,22 @@
 
 ## Project Overview
 **TripLog** is a CLI-centric desktop application designed for travelers who prefer managing their itineraries via a terminal interface. It allows users to track destinations and trip schedules, providing a streamlined, keyboard-first alternative to traditional GUI-based travel planners.
+
 ### Summary of Contributions
 
 * **Code Contribution**: [Link to Repo Analyzer](https://nus-cs2103-ay2526-s2.github.io/tp-dashboard/?search=&sort=groupTitle&sortWithin=title&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=true&checkedFileTypes=docs~functional-code~test-code~other&since=2026-02-20T00%3A00%3A00&filteredFileName=&tabOpen=true&tabType=authorship&tabAuthor=ths1959&tabRepo=AY2526S2-CS2103-F13-2%2Ftp%5Bmaster%5D&authorshipIsMergeGroup=false&authorshipFileTypes=docs~functional-code~test-code~other&authorshipIsBinaryFileTypeChecked=false&authorshipIsIgnoredFilesChecked=false)
 * **Feature Enhanced: Multi-Key Sorting and Temporal Dashboard**
-    * **What it does**: Enhanced the `list` command to support dynamic sorting by `name`, `start date`, `end date`, and `duration`. It also introduced a "Temporal Dashboard" that summarizes trips into categories: *Upcoming*, *Ongoing*, *Completed*, and *Planning*.
-    * **Justification**: As a trip log grows, a simple list becomes unmanageable. Users need to see what is happening *now* versus what is planned. Sorting by duration helps in prioritizing long-haul vs. short trips, and the alphabetical tie-breaker ensures the UI remains deterministic.
-    * **Highlights**: Implemented a **Comparator Factory** pattern to handle multiple sort keys and a multi-level tie-breaker system using Java’s `.thenComparing()` logic.
+  * **What it does**: Enhanced the `list` command to support dynamic sorting by `name`, `start date`, `end date`, and `duration`. It also introduced a "Temporal Dashboard" that summarizes trips into categories: *Upcoming*, *Ongoing*, *Completed*, and *Planning*.
+  * **Justification**: As a trip log grows, a simple list becomes unmanageable. Users need to see what is happening *now* versus what is planned. Sorting by duration helps in prioritizing long-haul vs. short trips, and the alphabetical tie-breaker ensures the UI remains deterministic.
+  * **Highlights**: Implemented a **Comparator Factory** pattern to handle multiple sort keys and a multi-level tie-breaker system using Java’s `.thenComparing()` logic.
 
 * **Documentation Contributions**:
-    * **User Guide**: Authored the section on "Listing all trips," detailing the sorting syntax and the logic behind the Dashboard categories.
-    * **Developer Guide**: Added the implementation details for the sorting mechanism, including a sequence diagram illustrating the interaction between the `Logic` and `Model` components during a sort operation.
+  * **User Guide**: Authored the section on "Listing all trips," detailing the sorting syntax and the logic behind the Dashboard categories.
+  * **Developer Guide**: Added the implementation details for the sorting mechanism, including a sequence diagram illustrating the interaction between the `Logic` and `Model` components during a sort operation.
 
 * **Quality Assurance & Testing**:
-    * Reported **5 critical alpha-bugs** during the internal testing phase, focusing on data robustness and input validation.
-    * Identified a significant "Silent Failure" bug where corrupted storage files would result in an empty list without notifying the user, potentially leading to accidental data loss.
+  * Reported **9 alpha-bugs** during the internal testing phase, ranging from high-severity data corruption risks to UI/UX inconsistencies.
+  * Identified a critical "Silent Failure" bug where corrupted storage files resulted in an empty list without notifying the user, and a "Reserved Keyword" bug where using `null` as a tag risked crashing the JSON parser.
 
 ---
 
@@ -65,8 +66,12 @@ The calculation is centralized in `TripSummaryUtil#calculateSummary()`. It deter
 ## Review of Alpha Bugs Reported
 | ID | Title | Severity |
 |---|---|------|
-| #156 | Application allows logically impossible years (0000/9999) | Low  |
+| #221 | ResultDisplay lacks vertical resizability | Low |
+| #207 | Residue AB3 "duplicate persons" error message | Low |
+| #190 | Help command displays error icon [!!] for valid usage | Low |
+| #184 | Summary dashboard missing on application startup | Low |
+| #156 | Application allows logically impossible years (0000/9999) | Low |
 | #155 | Application fails to notify user on corrupted triplog.json | Medium |
 | #154 | Find command fails to match partial words | Medium |
-| #153 | Command words are over-sensitive to case | Low  |
-| #152 | Allowed creation of trips with 'null' tag | High |
+| #153 | Command words are over-sensitive to case | Low |
+| #151 | Allowed creation of trips with 'null' tag | High |


### PR DESCRIPTION
Closes #229 

This PR updates the Project Portfolio page for ths1959.

**Changes:**
1. **QA & Testing**: Updated the total count of reported alpha-bugs to 9.
2. **Bug Review Table**: Added missing entries for UI resizability, startup dashboard presence, incorrect icon usage, and residue AB3 terminology.

All entries in the Portfolio have been verified against the current repository state and issue tracker.