### PR TITLE
edit malformed edit command row

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -349,7 +349,8 @@ _Details coming soon ..._
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Add** | `add n/NAME [p/PHONE] [e/EMAIL] [a/ADDRESS] [sd/DATE] [ed/DATE] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 sd/2026-01-01 t/friend` |
 | **Clear** | `clear`                                                                                                                                   |
-| **Delete** | `delete INDEX`<br>`delete START-END`<br>`delete PREFIX/VALUE`<br>`delete sd/START_DATE ed/END_DATE`<br> e.g., `delete 3`, `delete 1-3`, `delete t/family`, `delete sd/2026-03-01 ed/2026-05-10` || **Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [sd/DATE] [ed/DATE] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com` |
+| **Delete** | `delete INDEX`<br>`delete START-END`<br>`delete PREFIX/VALUE`<br>`delete sd/START_DATE ed/END_DATE`<br> e.g., `delete 3`, `delete 1-3`, `delete t/family`, `delete sd/2026-03-01 ed/2026-05-10` |
+| **Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [sd/DATE] [ed/DATE] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com` |
 | **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find Tokyo Osaka`                                                                                                              |
 | **List** | `list [sort/KEY]` <br> e.g., `list sort/name`                                                                                                                            |                                                                                                                                                                 |
 | **Help** | `help [COMMAND]`<br> e.g., `help add`                                                                                                                                    |


### PR DESCRIPTION
This PR aims to resovle #240 on edit command not showing in the table at bottom of user guide

<img width="701" height="530" alt="Screenshot 2026-04-04 at 2 18 04 PM" src="https://github.com/user-attachments/assets/c21d9a2a-d5cf-4529-be24-288ea114b5e7" />

## Summary of changes
- added closing pipe between delete and edit command row in `UserGuide.md` to ensure proper termination