### PR TITLE
Standardize List Command header in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -197,7 +197,7 @@ The following sequence diagram illustrates the process of filtering a trip:
 
 <puml src="diagrams/FilterSequenceDiagram.puml" alt="Filter Command Sequence Diagram" />
 
-### Trip Statistics and Multi-Key Sorting
+### Trip Listing and Sorting: List Command
 
 #### Implementation
 


### PR DESCRIPTION
Closes #242

Renamed the "Trip Statistics and Multi-Key Sorting" section in `docs/DeveloperGuide.md` to "Trip Listing and Sorting: List Command".

This update ensures the header follows the naming convention established for the Add, Delete, Tag, and Filter commands, maintaining structural consistency across the Implementation section.