### PR TITLE
fix stale error messages

### DIFF
--- a/src/main/java/seedu/triplog/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/triplog/logic/commands/AddCommand.java
@@ -3,8 +3,10 @@ package seedu.triplog.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.triplog.logic.parser.CliSyntax.PREFIX_END_DATE;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.triplog.logic.parser.CliSyntax.PREFIX_START_DATE;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.triplog.commons.util.ToStringBuilder;
@@ -23,17 +25,16 @@ public class AddCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a trip to the trip log. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
-            + PREFIX_PHONE + "PHONE "
-            + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_ADDRESS + "ADDRESS "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_START_DATE + "START_DATE] "
+            + "[" + PREFIX_END_DATE + "END_DATE] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe "
-            + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_NAME + "Tokyo "
+            + PREFIX_START_DATE + "2026-03-10 "
+            + PREFIX_END_DATE + "2026-03-20";
 
     public static final String MESSAGE_SUCCESS = "New trip added: %1$s\n%2$s";
     public static final String MESSAGE_DUPLICATE_TRIP = "This trip already exists in the trip log";

--- a/src/main/java/seedu/triplog/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/triplog/logic/commands/EditCommand.java
@@ -3,8 +3,10 @@ package seedu.triplog.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.triplog.logic.parser.CliSyntax.PREFIX_END_DATE;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.triplog.logic.parser.CliSyntax.PREFIX_START_DATE;
 import static seedu.triplog.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.triplog.model.Model.PREDICATE_SHOW_ALL_TRIPS;
 
@@ -45,6 +47,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_START_DATE + "START_DATE] "
+            + "[" + PREFIX_END_DATE + "END_DATE] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "


### PR DESCRIPTION
## Description     

This PR fixes 2 bugs related to stale / incomplete command documentation shown to users when they enter invalid commands

### Summary of changes: 
1. `AddCommand.java`
  - Wrapped [p/PHONE], [e/EMAIL], [a/ADDRESS] in square brackets to correctly reflect their optional status
  - Added [sd/START_DATE] and [ed/END_DATE] to the parameters list
  - Replaced the person-style example with a trip-relevant one: add n/Tokyo sd/2026-03-10 ed/2026-03-20
  - Added missing imports for PREFIX_START_DATE and PREFIX_END_DATE

2. `EditCommand.java`
  - Added [sd/START_DATE] and [ed/END_DATE] to the parameters list in MESSAGE_USAGE
  - Added missing imports for PREFIX_START_DATE and PREFIX_END_DATE