### PR TITLE
set initial size for window

### DIFF
--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -10,7 +10,9 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="true" title="TripLog - Command Syntax Guide" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="true" title="TripLog - Command Syntax Guide" type="javafx.stage.Stage"
+        width="550" height="600"
+        xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>


### PR DESCRIPTION
This PR aims to resolve #251 on overflow of help window.

## Description

- `HelpWindow.fxml` had no width or height on the `<fx:root>` Stage element, so JavaFX auto-sized the window to fit all its content (10 command-usage labels plus separators) resulting in an excessively tall window.

## Summary of changes
- Added `width="550" height="600"` to the Stage declaration in `HelpWindow.fxml`. The existing ScrollPane with `vbarPolicy="AS_NEEDED"` already handles overflow, so all content will still remain accessible via scrolling.