### PR TITLE
Update list command description in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -140,7 +140,7 @@ Supported `KEY` values:
 - `len`: Sorts by duration of the trip (longest first).
 
 Examples:
-- `list` — Displays all trips ordered by start date and shows a summary (e.g. `Listed all trips sorted by start date. Summary: 1 Upcoming, 1 Ongoing, 5 Completed, 1 Planning`).
+- `list` — Displays all trips using the last active sort order (or start date by default) and shows a summary (e.g. `Listed all trips sorted by start date. Summary: 1 Upcoming, 1 Ongoing, 5 Completed, 1 Planning`).
 - `list sort/name` — Displays all trips in alphabetical order.
 - `list sort/len` — Displays all trips starting with the longest durations.
 
@@ -182,7 +182,7 @@ Format: `tag INDEX TAG`
 Examples:
 * `tag 1 scenic beauty` Tags the 1st trip with `scenic beauty`.
 * `tag 2 hotel` Tags the 2nd trip with `hotel`.
-![result for 'tag 2 hotel'.png](images/tag2HotelResult.png)
+  ![result for 'tag 2 hotel'.png](images/tag2HotelResult.png)
 
 ### Locating trips by name: `find`
 


### PR DESCRIPTION
This PR addresses a documentation discrepancy where the `list` command example incorrectly suggested a reset to start-date ordering. It clarifies that the command respects the persistent sort order.

#### Key Implementation Details
- Modified `docs/UserGuide.md` to update the description of the `list` example.
- Ensured the text aligns with the persistence feature mentioned in the feature description.

Fixes #321