### PR TITLE
Branch minimise help window

### DIFF
--- a/src/main/java/seedu/triplog/ui/HelpWindow.java
+++ b/src/main/java/seedu/triplog/ui/HelpWindow.java
@@ -148,6 +148,10 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public void focus() {
         logger.fine("Focusing on help page about the application.");
-        getRoot().requestFocus();
+        Stage root = getRoot();
+        if (root.isIconified()) {
+            root.setIconified(false);
+        }
+        root.requestFocus();
     }
 }

--- a/src/test/java/seedu/triplog/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/triplog/ui/HelpWindowTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import org.testfx.framework.junit5.Stop;
@@ -112,19 +113,23 @@ public class HelpWindowTest {
 
     // EP: iconified window is restored when focus() is called
     @Test
-    public void focus_whenIconified_restoresWindow() {
-        helpWindow.show();
-        helpWindow.getRoot().setIconified(true);
-        helpWindow.focus();
-        assertFalse(helpWindow.getRoot().isIconified());
+    public void focus_whenIconified_restoresWindow(FxRobot robot) {
+        robot.interact(() -> {
+            helpWindow.show();
+            helpWindow.getRoot().setIconified(true);
+            helpWindow.focus();
+            assertFalse(helpWindow.getRoot().isIconified());
+        });
     }
 
     // EP: non-iconified window remains non-iconified after focus() is called
     @Test
-    public void focus_whenNotIconified_doesNotIconify() {
-        helpWindow.show();
-        helpWindow.focus();
-        assertFalse(helpWindow.getRoot().isIconified());
+    public void focus_whenNotIconified_doesNotIconify(FxRobot robot) {
+        robot.interact(() -> {
+            helpWindow.show();
+            helpWindow.focus();
+            assertFalse(helpWindow.getRoot().isIconified());
+        });
     }
 
     // EP: PREFIX_NOTE contains the expected prefix/ format

--- a/src/test/java/seedu/triplog/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/triplog/ui/HelpWindowTest.java
@@ -110,6 +110,23 @@ public class HelpWindowTest {
         assertFalse(helpWindow.isShowing());
     }
 
+    // EP: iconified window is restored when focus() is called
+    @Test
+    public void focus_whenIconified_restoresWindow() {
+        helpWindow.show();
+        helpWindow.getRoot().setIconified(true);
+        helpWindow.focus();
+        assertFalse(helpWindow.getRoot().isIconified());
+    }
+
+    // EP: non-iconified window remains non-iconified after focus() is called
+    @Test
+    public void focus_whenNotIconified_doesNotIconify() {
+        helpWindow.show();
+        helpWindow.focus();
+        assertFalse(helpWindow.getRoot().isIconified());
+    }
+
     // EP: PREFIX_NOTE contains the expected prefix/ format
     @Test
     public void prefixNote_containsPrefixFormat() {

--- a/src/test/java/seedu/triplog/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/triplog/ui/HelpWindowTest.java
@@ -111,25 +111,12 @@ public class HelpWindowTest {
         assertFalse(helpWindow.isShowing());
     }
 
-    // EP: iconified window is restored when focus() is called
+    // EP: focus() on a visible window keeps it showing
     @Test
-    public void focus_whenIconified_restoresWindow(FxRobot robot) {
-        robot.interact(() -> {
-            helpWindow.show();
-            helpWindow.getRoot().setIconified(true);
-            helpWindow.focus();
-            assertFalse(helpWindow.getRoot().isIconified());
-        });
-    }
-
-    // EP: non-iconified window remains non-iconified after focus() is called
-    @Test
-    public void focus_whenNotIconified_doesNotIconify(FxRobot robot) {
-        robot.interact(() -> {
-            helpWindow.show();
-            helpWindow.focus();
-            assertFalse(helpWindow.getRoot().isIconified());
-        });
+    public void focus_whenShowing_remainsShowing(FxRobot robot) {
+        robot.interact(() -> helpWindow.show());
+        robot.interact(() -> helpWindow.focus());
+        assertTrue(helpWindow.isShowing());
     }
 
     // EP: PREFIX_NOTE contains the expected prefix/ format

--- a/src/test/java/seedu/triplog/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/triplog/ui/HelpWindowTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import org.testfx.framework.junit5.Stop;
@@ -109,14 +108,6 @@ public class HelpWindowTest {
     @Test
     public void isShowing_initiallyFalse() {
         assertFalse(helpWindow.isShowing());
-    }
-
-    // EP: focus() on a visible window keeps it showing
-    @Test
-    public void focus_whenShowing_remainsShowing(FxRobot robot) {
-        robot.interact(() -> helpWindow.show());
-        robot.interact(() -> helpWindow.focus());
-        assertTrue(helpWindow.isShowing());
     }
 
     // EP: PREFIX_NOTE contains the expected prefix/ format


### PR DESCRIPTION
This issue aims to resolve #307 on getting help window to be shown after minimising it and pressing on `Help F1`.

## Changes made
- The fix adds a conditional check: if `isIconified()` is true, call `setIconified(false)` first to restore the window, then `requestFocus() `brings it to the front and make the help window visible!