### PR TITLE
Fix UI list collapse in MainWindow SplitPane

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -71,7 +71,7 @@
               </padding>
             </StackPane>
 
-            <VBox fx:id="tripList" styleClass="pane-with-border" minWidth="0">
+            <VBox fx:id="tripList" styleClass="pane-with-border" minWidth="0" minHeight="100">
               <padding>
                 <Insets top="10" right="10" bottom="10" left="10" />
               </padding>


### PR DESCRIPTION
This PR fixes a UI bug where the trip list panel would collapse to zero height when displaying a large number of entries. This ensures the list remains visible and responsive within the `SplitPane`.

#### Key Implementation Details
- Modified `src/main/resources/view/MainWindow.fxml` to define a `minHeight` for the `tripList` VBox.
- Prevented the `SplitPane` from starving the list panel of space when the `ResultDisplay` is active.

Fixes #291