### PR TITLE
Clarify start-date sorting behavior in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -130,7 +130,7 @@ Format: `list [sort/KEY]`
 
 - By default, trips are sorted by **start date** in ascending order (earliest first).
 - **Tie-breaker**: If multiple trips share the same date or length, they are automatically sorted alphabetically by name.
-- Trips with no start date are shown last.
+- **When sorting by start date (default)**, trips with no start date are shown last.
 - The sort order is **persistent**: adding or editing trips will maintain the last chosen sort order, **even after restarting the application.**
 
 Supported `KEY` values:


### PR DESCRIPTION
This PR updates the User Guide to specify that the "no start date shown last" rule applies primarily to the default start-date sorting. This addresses a potential misunderstanding where users might expect planning trips to always remain at the bottom regardless of the active sort key.

#### Key Implementation Details
- Modified `docs/UserGuide.md` in the `list` command section.
- Updated the bullet point for missing start dates to explicitly link the behavior to the default sorting mode.

#### Documentation
- Fixes #285