### PR TITLE
add width to help window in ug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -74,7 +74,7 @@ Format: `help [COMMAND]`
 - Without arguments, `help` opens a help window showing syntax for all commands.
 - With a command name, `help COMMAND` displays the usage for that specific command inline in the result display (no window opens).
 
-<img src="images/helpMessage.png" width="700" />
+<img src="images/helpMessage.png" width="850" />
 
 Examples:
 - `help` — opens the full help window.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -74,7 +74,7 @@ Format: `help [COMMAND]`
 - Without arguments, `help` opens a help window showing syntax for all commands.
 - With a command name, `help COMMAND` displays the usage for that specific command inline in the result display (no window opens).
 
-![help message](images/helpMessage.png)
+<img src="images/helpMessage.png" width="700" />
 
 Examples:
 - `help` — opens the full help window.


### PR DESCRIPTION
This PR aims to resolve #340 

## Changes made
- markdown image syntax was replaced with an HTML `<img>` tag with width="850" to constrain the size of the help window screenshot in the User Guide.