### PR TITLE
Document handling of duplicate parameters in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -131,7 +131,7 @@ The **Summary Dashboard** categorizes your trips based on the current date:
 
 Format: `list [sort/KEY]`
 
-- By default, trips are sorted by **start date** in ascending order (earliest first).
+- By default, trips are sorted by the **last active sort order**. If no sort has been previously used, the **start date** in ascending order is used as a fallback.
 - **Tie-breaker**: If multiple trips share the same date or length, they are automatically sorted alphabetically by name.
 - Trips with no start date are shown last.
 - The sort order is **persistent**: adding or editing trips will maintain the last chosen sort order, **even after restarting the application.**
@@ -143,7 +143,7 @@ Supported `KEY` values:
 - `len`: Sorts by duration of the trip (longest first).
 
 Examples:
-- `list` — Displays all trips ordered by start date and shows a summary (e.g. `Listed all trips sorted by start date. Summary: 1 Upcoming, 1 Ongoing, 5 Completed, 1 Planning`).
+- `list` — Displays all trips using the last active sort order (or start date by default) and shows a summary (e.g. `Listed all trips sorted by start date. Summary: 1 Upcoming, 1 Ongoing, 5 Completed, 1 Planning`).
 - `list sort/name` — Displays all trips in alphabetical order.
 - `list sort/len` — Displays all trips starting with the longest durations.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -62,6 +62,9 @@ TripLog is a **desktop app for managing trips, optimized for use via a Command L
 - Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE`, `p/PHONE n/NAME` is also acceptable.
 
+- If a parameter is expected only once but is specified multiple times, only the last occurrence will be used.<br>
+  e.g. `list sort/name sort/start` will sort by start date.
+
 - For commands that do not take parameters (such as `exit` and `clear`), extraneous parameters will be ignored.
   </box>
 
@@ -140,7 +143,7 @@ Supported `KEY` values:
 - `len`: Sorts by duration of the trip (longest first).
 
 Examples:
-- `list` — Displays all trips using the last active sort order (or start date by default) and shows a summary (e.g. `Listed all trips sorted by start date. Summary: 1 Upcoming, 1 Ongoing, 5 Completed, 1 Planning`).
+- `list` — Displays all trips ordered by start date and shows a summary (e.g. `Listed all trips sorted by start date. Summary: 1 Upcoming, 1 Ongoing, 5 Completed, 1 Planning`).
 - `list sort/name` — Displays all trips in alphabetical order.
 - `list sort/len` — Displays all trips starting with the longest durations.
 


### PR DESCRIPTION
This PR updates the User Guide to clarify how the application handles multiple occurrences of the same parameter prefix. This addresses a reported ambiguity regarding the `list` command and ensures users understand that the system defaults to the final argument provided.

#### Key Implementation Details
- Modified `docs/UserGuide.md` in the "Notes about the command format" section.
- Added a new bullet point explaining the "last-occurrence" rule for single-value parameters.
- Provided an example using `list sort/name sort/start` for clarity.

#### Documentation
- Fixes #280