### PR TITLE
Throw error when user inputs multiple duplicate tags

### DIFF
--- a/src/main/java/seedu/triplog/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/triplog/logic/parser/AddCommandParser.java
@@ -47,7 +47,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(
             PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-            PREFIX_START_DATE, PREFIX_END_DATE, PREFIX_TAG);
+            PREFIX_START_DATE, PREFIX_END_DATE);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
 
         Optional<String> maybePhone = argMultimap.getValue(PREFIX_PHONE);

--- a/src/main/java/seedu/triplog/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/triplog/logic/parser/AddCommandParser.java
@@ -47,7 +47,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(
             PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-            PREFIX_START_DATE, PREFIX_END_DATE);
+            PREFIX_START_DATE, PREFIX_END_DATE, PREFIX_TAG);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
 
         Optional<String> maybePhone = argMultimap.getValue(PREFIX_PHONE);

--- a/src/main/java/seedu/triplog/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/triplog/logic/parser/ParserUtil.java
@@ -23,6 +23,7 @@ import seedu.triplog.model.trip.TripDate;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_DUPLICATE_TAG = "Duplicate tags are not allowed: ";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -120,7 +121,7 @@ public class ParserUtil {
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
             if (!tagSet.add(parseTag(tagName))) {
-                throw new ParseException("Duplicate tags are not allowed: " + tagName);
+                throw new ParseException(MESSAGE_DUPLICATE_TAG + tagName);
             }
         }
         return tagSet;

--- a/src/main/java/seedu/triplog/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/triplog/logic/parser/ParserUtil.java
@@ -119,7 +119,9 @@ public class ParserUtil {
         requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
-            tagSet.add(parseTag(tagName));
+            if (!tagSet.add(parseTag(tagName))) {
+                throw new ParseException("Duplicate tags are not allowed: " + tagName);
+            }
         }
         return tagSet;
     }


### PR DESCRIPTION
Previous commands like "add n/test t/a t/a" was allowed and added a single 'a' tag. Now it throws an error message.

Closes #333 

## Updated
**ParserUtil:** Added a line in `parseTags` method to throw an exception if duplicate tag already exists.