### PR TITLE
Improve date error message for clarity

### DIFF
--- a/src/main/java/seedu/triplog/model/trip/TripDate.java
+++ b/src/main/java/seedu/triplog/model/trip/TripDate.java
@@ -17,7 +17,8 @@ public class TripDate {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Dates should be in YYYY-MM-DD format and between " + MIN_YEAR
-                    + "-01-01 and " + MAX_YEAR + "-12-31";
+                    + "-01-01 and " + MAX_YEAR + "-12-31."
+                    + " Please ensure it is also an actual date (e.g. Feb is only up till 28).";
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
 


### PR DESCRIPTION
Previously the date error message only showed format. But dates like '2026-02-31' which seems valid at first glance but is not (Feb 28 at most) might confuse users.

Closes #292 

## Updated
**TripDate:** Added a line in date error constraint to ask user to check if date is valid.