### PR TITLE
Fix preview bypass bug

### DIFF
--- a/src/main/java/seedu/triplog/ui/CommandBox.java
+++ b/src/main/java/seedu/triplog/ui/CommandBox.java
@@ -1,4 +1,5 @@
 package seedu.triplog.ui;
+import static seedu.triplog.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import javafx.animation.TranslateTransition;
 import javafx.fxml.FXML;
@@ -64,6 +65,12 @@ public class CommandBox extends UiPart<Region> {
         boolean isDeleteCommand = lowerTrimmedCommandText.equals("delete")
                 || lowerTrimmedCommandText.startsWith("delete ");
         try {
+            boolean isPreviewDeleteCommand = lowerTrimmedCommandText.equals("deletepreview")
+                    || lowerTrimmedCommandText.startsWith("deletepreview ");
+
+            if (isPreviewDeleteCommand) {
+                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            }
             if (isDeleteCommand) {
                 // Second Enter on the exact same delete command -> confirm actual deletion
                 if (deletePendingConfirmation && commandText.equalsIgnoreCase(lastDeleteCommand)) {

--- a/src/main/java/seedu/triplog/ui/CommandBox.java
+++ b/src/main/java/seedu/triplog/ui/CommandBox.java
@@ -60,12 +60,13 @@ public class CommandBox extends UiPart<Region> {
         }
 
         String trimmedCommandText = commandText.trim();
-        boolean isDeleteCommand = trimmedCommandText.equals("delete")
-                || trimmedCommandText.startsWith("delete ");
+        String lowerTrimmedCommandText = trimmedCommandText.toLowerCase();
+        boolean isDeleteCommand = lowerTrimmedCommandText.equals("delete")
+                || lowerTrimmedCommandText.startsWith("delete ");
         try {
             if (isDeleteCommand) {
                 // Second Enter on the exact same delete command -> confirm actual deletion
-                if (deletePendingConfirmation && commandText.equals(lastDeleteCommand)) {
+                if (deletePendingConfirmation && commandText.equalsIgnoreCase(lastDeleteCommand)) {
                     commandExecutor.execute(commandText);
                     commandTextField.setText("");
                     deletePendingConfirmation = false;


### PR DESCRIPTION
### Fix delete preview bypass and block direct access to internal preview command

Fixes a bug where uppercase/mixed-case delete commands (e.g. `DELETE`, `dElEtE`) bypassed the preview flow and deleted trips directly. Also prevents users from invoking the internal `deletepreview` command directly.

#### Changes made
- Updated delete command detection in `CommandBox` to be case-insensitive
- Updated delete confirmation matching to be case-insensitive for consistent second-enter confirmation
- Blocked direct user access to `deletepreview`, which is intended for internal preview flow only

#### Result
- All valid delete command variants now consistently show preview before deletion
- Internal preview command can no longer be triggered directly by users

Closes #362
Closes #361  