### PR TITLE
add notes to separate examples

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -81,6 +81,7 @@ Examples:
 - `help add` — shows the usage for the `add` command inline.
 - `help delete` — shows the usage for the `delete` command inline.
 
+Notes:
 - The help window can also be opened by pressing **F1** or using the Help menu.
 - The help window can be closed by clicking the 'x' button, or by pressing **Q** or **ESCAPE** while the window is focused.
 - The help window is resizable — drag any edge or corner to adjust its size.


### PR DESCRIPTION
This PR aims to resolve #345 on separating the examples from the non examples in the help section by including a `Notes` section