### PR TITLE
Add clarity on delete command features in dg

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -92,9 +92,9 @@ Here's a (partial) class diagram of the `Logic` component:
 
 <puml src="diagrams/LogicClassDiagram.puml" width="550"/>
 
-The sequence diagram below illustrates the interactions within the `Logic` component, taking `execute("delete 1")` API call as an example.
+The sequence diagram below illustrates the interactions within the `Logic` component, taking `execute("delete 1-3")` API call as an example.
 
-<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the Logic Component for the `delete 1` Command" />
+<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the Logic Component for the `delete 1-3` Command" />
 
 <box type="info" seamless>
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -557,38 +557,30 @@ testers are expected to do more *exploratory* testing.
 ### Deleting a trip
 
 1. Deleting a trip using index
-
     1. Prerequisites: List all trips using the `list` command. Multiple trips in the list.
-
     2. Test case: `delete 1`  
        Expected: A preview of the first trip is shown. No trip is deleted yet.
-
     3. Test case: Press Enter again with `delete 1`  
        Expected: First trip is deleted from the list. Details of the deleted trip shown in the status message.
 
 2. Cancelling deletion
-
     1. Test case: `delete 1`, then modify the command instead of confirming  
        Expected: No trip is deleted.
 
 3. Invalid index
-
     1. Test case: `delete 0`  
        Expected: No trip is deleted. Error message shown.
 
 4. Deleting a range of trips
-
     1. Test case: `delete 1-3`  
        Expected: Preview of trips 1 to 3 is shown.  
        After confirmation, all three trips are deleted.
 
 5. Deleting by field
-
     1. Test case: `delete n/Tokyo`  
        Expected: All trips with name "Tokyo" are previewed, then deleted after confirmation.
 
 6. Deleting by date range
-
     1. Test case: `delete sd/2026-03-01 ed/2026-05-10`  
        Expected: Trips matching the specified date range are previewed, then deleted after confirmation.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -186,10 +186,12 @@ The `delete` command removes trip(s) from the currently displayed trip list. It 
 
 The parsing of the command is handled by `DeleteCommandParser`, which determines which of the four deletion modes is being used based on input format and validates that only one mode is specified per command.
 
-Deletion is performed by `DeleteCommand`, which operates on the **currently displayed trip list**. For criteria-based deletion, a `TripMatchesDeletePredicate` is used, where:
-* different fields are combined using AND logic
-* tags are matched using OR logic
-* date ranges (`sd/` and `ed/`) match trips within the specified period
+Deletion is performed by `DeleteCommand`, which operates on the **currently displayed trip list**. 
+For field-match and date-range deletion, matching is handled by `TripMatchesDeletePredicate`:
+* field-match deletion checks one specified prefix at a time (e.g. `n/`, `p/`, `t/`, `sd/`)
+* date-range deletion (`sd/` and `ed/`) works as follows:
+    * different dates → trip start date must be on/after `sd`, and end date must be on/before `ed`
+    * same date → any trip happening on that day matches
 
 To prevent accidental deletion, a **two-step confirmation flow** is implemented in `CommandBox`:
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -178,13 +178,13 @@ The `edit` command utilizes `Model#hasTripExcluding(Trip, Trip)`. This ensures t
 
 ### Trip Deletion: Delete Command
 
-The `delete` command removes trip(s) from the currently displayed trip list. It supports three deletion modes:
-
+The `delete` command removes trip(s) from the currently displayed trip list. It supports four deletion modes:
 * **Single deletion**: deletes a trip at a given index (e.g. `delete 2`)
 * **Range deletion**: deletes trips within an index range (e.g. `delete 1-3`)
-* **Criteria-based deletion**: deletes trips matching a field (e.g. `delete n/Tokyo`, `delete t/family`, `delete sd/2026-01-01 ed/2026-12-31`)
+* **Field-match deletion**: deletes trips matching a field such as name or tag (e.g. `delete n/Tokyo`, `delete t/family`)
+* **Date-range deletion**: deletes trips within a specified date range (e.g. `delete sd/2026-01-01 ed/2026-12-31`)
 
-The parsing of the command is handled by `DeleteCommandParser`, which determines the deletion mode based on input format and validates that only one mode is used.
+The parsing of the command is handled by `DeleteCommandParser`, which determines which of the four deletion modes is being used based on input format and validates that only one mode is specified per command.
 
 Deletion is performed by `DeleteCommand`, which operates on the **currently displayed trip list**. For criteria-based deletion, a `TripMatchesDeletePredicate` is used, where:
 * different fields are combined using AND logic

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -274,8 +274,9 @@ Examples:
 
 #### Delete by date range
 
-- Deletes all trips whose start and end dates match the specified range using both `sd/` and `ed/`.
-- Both `sd/START_DATE` and `ed/END_DATE` must be provided.
+- Deletes trips using both `sd/START_DATE` and `ed/END_DATE`.
+- If different start and end dates are given, a trip is deleted only if its start date is on or after `sd/START_DATE`and its end date is on or before `ed/END_DATE`.
+- If both dates are the same, all trips happening on that day are deleted.
 - Dates must be in `YYYY-MM-DD` format.
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -218,9 +218,7 @@ Press **Enter again** to confirm the deletion, or edit the command to cancel.
 Format:<br>
 `delete INDEX`<br>
 `delete START-END`<br>
-`delete PREFIX/VALUE`<br>
-`delete sd/START_DATE`<br>
-`delete ed/END_DATE`<br>
+`delete PREFIX/VALUE` (where `PREFIX` is one of `n/`, `p/`, `e/`, `a/`, `sd/`, `ed/`, or `t/`)<br>
 `delete sd/START_DATE ed/END_DATE`
 
 - Only one delete mode may be used at a time (e.g. `delete 1 t/family` is invalid).

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -215,14 +215,18 @@ Press **Enter again** to confirm the deletion, or edit the command to cancel.
 
 </box>
 
-Format:
-`delete INDEX`
-`delete START-END`
-`delete PREFIX/VALUE`
+Format:<br>
+`delete INDEX`<br>
+`delete START-END`<br>
+`delete PREFIX/VALUE`<br>
+`delete sd/START_DATE`<br>
+`delete ed/END_DATE`<br>
 `delete sd/START_DATE ed/END_DATE`
 
 - Only one delete mode may be used at a time (e.g. `delete 1 t/family` is invalid).
 - The command operates on the currently displayed trip list.
+- If `sd/` or `ed/` is used alone, TripLog performs exact single-date matching.
+- If both `sd/` and `ed/` are provided together, TripLog interprets it as date-range deletion instead.
 
 #### Delete by index
 


### PR DESCRIPTION
### Fix inconsistent delete mode documentation in DG

Resolves a documentation inconsistency where the Developer Guide stated that `delete` supports three modes, while another section correctly described four distinct modes.

#### Changes made
- Updated Delete Command section in DG from “three deletion modes” to “four deletion modes”
- Split criteria-based deletion into:
  - Field-match deletion
  - Date-range deletion
- Clarified `DeleteCommandParser` explanation to explicitly reference all four modes
- Improved UG wording and formatting for delete command

Closes #359
Closes #338  
Closes #336 
Closes #311 
Closes #302 
Closes #284 
Closes #318 