### PR TITLE
Reset trip list filter after add/edit commands

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -186,7 +186,7 @@ The `delete` command removes trip(s) from the currently displayed trip list. It 
 
 The parsing of the command is handled by `DeleteCommandParser`, which determines which of the four deletion modes is being used based on input format and validates that only one mode is specified per command.
 
-Deletion is performed by `DeleteCommand`, which operates on the **currently displayed trip list**. 
+Deletion is performed by `DeleteCommand`, which operates on the **currently displayed trip list**.
 For field-match and date-range deletion, matching is handled by `TripMatchesDeletePredicate`:
 * field-match deletion checks one specified prefix at a time (e.g. `n/`, `p/`, `t/`, `sd/`)
 * date-range deletion (`sd/` and `ed/`) works as follows:
@@ -468,6 +468,11 @@ testers are expected to do more *exploratory* testing.
     1. Test case: `add sd/2026-06-01 ed/2026-06-10`
        Expected: Error message indicating invalid command format. No trip is added.
 
+8. Adding a trip while list is filtered
+    1. Prerequisites: Use `filter` to hide some existing trips.
+    2. Test case: `add n/New Hidden Trip sd/2021-01-01`
+       Expected: The list and summary automatically reset to show all trips, including the new entry.
+
 ### Editing a trip
 
 1. Prerequisites: List all trips using the `list` command. Multiple trips in the list.
@@ -502,6 +507,11 @@ testers are expected to do more *exploratory* testing.
 8. No fields provided
     1. Test case: `edit 1`
        Expected: Error message indicating at least one field must be provided.
+
+9. Editing a trip while list is filtered
+    1. Prerequisites: Use `filter` to hide some existing trips.
+    2. Test case: `edit 1 n/Renamed Trip`
+       Expected: The list and summary automatically reset to show all trips, including the updated entry.
 
 ### Listing, Sorting, and Statistics
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -77,7 +77,7 @@ Format: `help [COMMAND]`
 - Without arguments, `help` opens a help window showing syntax for all commands.
 - With a command name, `help COMMAND` displays the usage for that specific command inline in the result display (no window opens).
 
-Screenshot of the help window below: 
+Screenshot of the help window below:
 
 <img src="images/helpMessage.png" width="850" />
 
@@ -107,6 +107,7 @@ Format: `add n/NAME [p/PHONE] [e/EMAIL] [a/ADDRESS] [sd/START_DATE] [ed/END_DATE
 
 - Dates must be in `YYYY-MM-DD` format.
 - `START_DATE` must be earlier than or equal to `END_DATE`.
+- **Note:** Upon successful addition, any active filters (e.g. from the `filter` command) will be cleared to show the full trip list and update the Summary Dashboard.
 
 <box type="tip" seamless>
 
@@ -167,6 +168,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [sd/START_DATE] [ed
 - **Dates:** If you edit only the `sd/START_DATE` or `ed/END_DATE`, TripLog ensures the new date range remains valid (start date $\le$ end date).
 - **Tags:** When editing tags, the existing tags of the trip will be removed (i.e., replacement, not addition).
 - You can remove all the trip’s tags by typing `t/` without specifying any tags after it.
+- **Note:** Upon successful editing, any active filters will be cleared to show the full trip list and update the Summary Dashboard.
 
 Examples:
 

--- a/src/main/java/seedu/triplog/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/triplog/logic/commands/AddCommand.java
@@ -58,6 +58,7 @@ public class AddCommand extends Command {
         }
 
         model.addTrip(toAdd);
+        model.updateFilteredTripList(Model.PREDICATE_SHOW_ALL_TRIPS);
         String summary = TripSummaryUtil.calculateSummary(model.getFilteredTripList());
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd), summary));
     }

--- a/src/main/java/seedu/triplog/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/triplog/logic/commands/EditCommand.java
@@ -94,6 +94,7 @@ public class EditCommand extends Command {
         }
 
         model.setTrip(tripToEdit, editedTrip);
+        model.updateFilteredTripList(Model.PREDICATE_SHOW_ALL_TRIPS);
 
         String summary = TripSummaryUtil.calculateSummary(model.getFilteredTripList());
         return new CommandResult(String.format(MESSAGE_EDIT_TRIP_SUCCESS, Messages.format(editedTrip), summary));

--- a/src/test/java/seedu/triplog/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/triplog/logic/commands/AddCommandTest.java
@@ -224,6 +224,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void updateFilteredTripList(Predicate<Trip> predicate) {
+            // No action needed for stub verification
+        }
+
+        @Override
         public ObservableList<Trip> getFilteredTripList() {
             return FXCollections.observableList(personsAdded);
         }

--- a/src/test/java/seedu/triplog/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/triplog/logic/commands/EditCommandTest.java
@@ -49,6 +49,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new TripLog(model.getTripLog()), new UserPrefs());
         expectedModel.setTrip(model.getFilteredTripList().get(0), editedTrip);
+        expectedModel.updateFilteredTripList(Model.PREDICATE_SHOW_ALL_TRIPS);
 
         String expectedSummary = TripSummaryUtil.calculateSummary(expectedModel.getFilteredTripList());
         String expectedMessage = String.format(MESSAGE_EDIT_TRIP_SUCCESS, Messages.format(editedTrip), expectedSummary);
@@ -71,6 +72,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new TripLog(model.getTripLog()), new UserPrefs());
         expectedModel.setTrip(lastTrip, editedTrip);
+        expectedModel.updateFilteredTripList(Model.PREDICATE_SHOW_ALL_TRIPS);
 
         String expectedSummary = TripSummaryUtil.calculateSummary(expectedModel.getFilteredTripList());
         String expectedMessage = String.format(MESSAGE_EDIT_TRIP_SUCCESS, Messages.format(editedTrip), expectedSummary);
@@ -100,6 +102,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new TripLog(model.getTripLog()), new UserPrefs());
         expectedModel.setTrip(model.getFilteredTripList().get(0), editedTrip);
+        expectedModel.updateFilteredTripList(Model.PREDICATE_SHOW_ALL_TRIPS);
 
         String expectedSummary = TripSummaryUtil.calculateSummary(expectedModel.getFilteredTripList());
         String expectedMessage = String.format(MESSAGE_EDIT_TRIP_SUCCESS, Messages.format(editedTrip), expectedSummary);
@@ -156,6 +159,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new TripLog(model.getTripLog()), new UserPrefs());
         expectedModel.setTrip(model.getFilteredTripList().get(INDEX_FIRST_TRIP.getZeroBased()), editedTrip);
+        expectedModel.updateFilteredTripList(Model.PREDICATE_SHOW_ALL_TRIPS);
 
         String expectedSummary = TripSummaryUtil.calculateSummary(expectedModel.getFilteredTripList());
         String expectedMessage = String.format(


### PR DESCRIPTION
This PR addresses a UI bug where the trip list and Summary Dashboard remained filtered after an `add` or `edit` command. This caused newly created or modified trips to be hidden from view, providing no visual confirmation to the user.

## Key Implementation Details
* Modified `AddCommand#execute` to call `model.updateFilteredTripList(PREDICATE_SHOW_ALL_TRIPS)` upon success.
* Modified `EditCommand#execute` to call `model.updateFilteredTripList(PREDICATE_SHOW_ALL_TRIPS)` upon success.
* Ensures the `Model` state is fully visible before the `CommandResult` and `TripSummaryUtil` calculations are returned to the UI.

## Documentation
* Updated `UserGuide.md` to explicitly state that active filters are cleared after successful data modifications.
* Updated `DeveloperGuide.md` manual testing instructions to reflect the expected list reset behavior.

Fixes #363 and #334