### PR TITLE
update summary with missing commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -376,7 +376,10 @@ Furthermore, certain edits can cause the TripLog to behave in unexpected ways (e
 | **Add** | `add n/NAME [p/PHONE] [e/EMAIL] [a/ADDRESS] [sd/DATE] [ed/DATE] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 sd/2026-01-01 t/friend` |
 | **Clear** | `clear`                                                                                                                                   |
 | **Delete** | `delete INDEX`<br>`delete START-END`<br>`delete PREFIX/VALUE`<br>`delete sd/START_DATE ed/END_DATE`<br> e.g., `delete 3`, `delete 1-3`, `delete t/family`, `delete sd/2026-03-01 ed/2026-05-10` |
-| **Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [sd/DATE] [ed/DATE] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com` |
+| **Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [sd/DATE] [ed/DATE] [t/TAG]…​`<br> At least one field must be provided.<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com` |
+| **Exit** | `exit` |
+| **Filter** | `filter sd/START_DATE ed/END_DATE`<br> `START_DATE` must not be after `END_DATE`.<br> e.g., `filter sd/2026-05-01 ed/2026-07-31` |
 | **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find Tokyo Osaka`                                                                                                              |
-| **List** | `list [sort/KEY]` <br> e.g., `list sort/name`                                                                                                                            |                                                                                                                                                                 |
+| **List** | `list [sort/KEY]` <br> e.g., `list sort/name`                                                                                                                            |
+| **Tag** | `tag INDEX TAG`<br> e.g., `tag 1 adventure` |
 | **Help** | `help [COMMAND]`<br> e.g., `help add`                                                                                                                                    |


### PR DESCRIPTION
This PR aims to resolve #300 on adding missing commands to the command summary table in `docs/UserGuide.md`