### PR TITLE
Clarify data transfer process in FAQ

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -359,8 +359,8 @@ Furthermore, certain edits can cause the TripLog to behave in unexpected ways (e
 
 ## FAQ
 
-**Q**: How do I transfer my data to another Computer?<br>
-**A**: Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous TripLog home folder.
+**Q**: How do I transfer my data to another computer?<br>
+**A**: Install the app on the other computer. Then, locate the `triplog.json` file in the `data` folder of your original TripLog directory and use it to overwrite the default `triplog.json` file created on the new computer.
 
 ---
 


### PR DESCRIPTION
This PR resolves a documentation clarity issue where the data transfer instructions were too vague for end-users to follow effectively.

## Key Implementation Details
* **FAQ Refinement:** Updated the data transfer answer to provide explicit instructions on locating the data file.
* **Technical Specificity:** Identified the specific filename (`triplog.json`) and its directory (`data/`) to eliminate ambiguity during manual file migrations.

## Documentation
* **User Guide:** Modified the FAQ section to improve technical accuracy and user self-sufficiency when moving data between devices.

Fixes #312